### PR TITLE
Fix error when setting value to null.

### DIFF
--- a/code/LinkField.php
+++ b/code/LinkField.php
@@ -162,7 +162,7 @@ class LinkField extends DBField implements CompositeDBField {
 	 * @return boolean
 	 */
 	function exists(){
-		return ($this->page_id || $this->custom_url);
+		return ($this->page_id !== null || $this->custom_url !== null );
 	}
 	
 	public function getPageID() {


### PR DESCRIPTION
clearing the CustomURL didnt work, so once you have set a customURL, it is there for good and cannot be cleared. Needed to use strict checking on exists() to solve the problem
